### PR TITLE
Fix comment issues in CMakeLists.txt for compiler

### DIFF
--- a/runtime/compiler/CMakeLists.txt
+++ b/runtime/compiler/CMakeLists.txt
@@ -29,7 +29,8 @@
 
 if(OMR_ARCH_X86)
 	enable_language(ASM_NASM)
-	# We have to manually set thses since older cmake versions dont handle include directories for NASM properly
+	# We have to manually set these since cmake strips tailing slashes off of include directories
+	# and NASM versions before 2.14 require trailing slashes on the include directories to work properly
 	set(asm_inc_dirs
 		"-I${j9vm_SOURCE_DIR}/oti/"
 		"-I${CMAKE_CURRENT_SOURCE_DIR}/"


### PR DESCRIPTION
Updated comment to reflect that inclue path issue is related to nasm
version, not the cmake version

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>