### PR TITLE
Inline java.lang.Class.getComponentType() in Value Propagation

### DIFF
--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -1263,6 +1263,8 @@ public:
     */
    TR::Node * testAreSomeClassFlagsSet(TR::Node *j9ClassRefNode, uint32_t flagsToTest);
 
+   TR::Node * testAreSomeClassAndDepthFlagsSet(TR::Node *j9ClassRefNode, uint32_t flagsToTest);
+
    /**
     * \brief Load class flags field of the specified class and test whether the value type
     *        flag is set.
@@ -1289,6 +1291,8 @@ public:
     *         or zero otherwise
     */
    TR::Node * testIsClassIdentityType(TR::Node *j9ClassRefNode);
+
+   TR::Node * loadArrayClassComponentType(TR::Node *j9ClassRefNode);
 
    /**
     * \brief Test whether any of the specified flags is set on the array's component class


### PR DESCRIPTION
Also, mark result of inlined code for Object.getClass() as non-null.